### PR TITLE
docs: correct constants tag in styles documentation

### DIFF
--- a/docs/syntax/styles.mdx
+++ b/docs/syntax/styles.mdx
@@ -119,10 +119,10 @@ In the values of style properties constants can be used as well.
 
 ```xml
 <component>
-    <constants>
+    <consts>
         <int name="thin" value="2" help="Thin border"/>
         <color name="dark" value="0x333" help="A dark color for the button's background"/>
-    </constants>
+    </consts>
 
     <styles>
         <!-- Global constants can be used as well, e.g. #muted below  --> 


### PR DESCRIPTION
The "Relation to Constants" section of the styles page used `<constants>`, but the LVGL XML schema requires `<consts>` — which is what `docs/syntax/constants.mdx` and all 41 usages across `examples/`, `templates/`, `tutorials/` and `lvgl_widgets_xml/` already use. This was the only occurrence of `<constants>` in the docs.

Fixes PRO-1484

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the styles documentation to use the `<consts>` tag instead of `<constants>`, matching the LVGL XML schema and the other 41 usages across the docs. This was the only occurrence of the incorrect tag, and it fixes PRO-1484.

<sup>Written for commit a900dd836636ea0c7ffb3d4eaa7ac3784999ef0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lvgl/lvgl_pro/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

